### PR TITLE
Enable the FileLoader to handle absolute paths for the macro root directory.

### DIFF
--- a/lib/kumascript/loaders.js
+++ b/lib/kumascript/loaders.js
@@ -139,11 +139,15 @@ var FileLoader = ks_utils.Class(BaseLoader, {
         // Build the template map, associating lowercase template names
         // with their paths on the filesystem.
 
-        var dir = null,
+        var dirs = [],
+            dir = null,
             duplicates = {},
             template_map = this.template_map = {},
-            repo_dir = path.join(__dirname, '..', '..'),
-            dirs = [path.join(repo_dir, this.options.root_dir)];
+            macro_dir = this.macro_dir = path.resolve(
+                __dirname,
+                '..', '..',
+                this.options.root_dir
+            );
 
         function getTemplateName(fp) {
             // Returns the lowercase basename, without the extension.
@@ -170,6 +174,8 @@ var FileLoader = ks_utils.Class(BaseLoader, {
             }
         }
 
+        dirs.push(macro_dir);
+
         // Walk the directory tree under the specified root directory.
         while (dirs.length > 0) {
             dir = dirs.shift();
@@ -180,9 +186,8 @@ var FileLoader = ks_utils.Class(BaseLoader, {
             // Let's throw an error if no macros could be discovered, since
             // for now this is the only time we check and this loader is
             // useless if there are no macros.
-            var root_dir = path.resolve(repo_dir, this.options.root_dir);
             throw new Error(
-                `no macros could be found in "${root_dir}"`
+                `no macros could be found in "${macro_dir}"`
             );
         }
 
@@ -227,8 +232,7 @@ var FileLoader = ks_utils.Class(BaseLoader, {
     //  filename: path to filename in macros folder
     macros_details: function() {
         var macros = [],
-            repo_dir = path.join(__dirname, '..', '..'),
-            macro_dir = path.join(repo_dir, this.options.root_dir) + path.sep;
+            macro_dir = this.macro_dir + path.sep;
         for (var lc_name in this.template_map) {
             var fp = this.template_map[lc_name],
                 name = path.parse(fp).name,

--- a/macros/Compat.ejs
+++ b/macros/Compat.ejs
@@ -54,8 +54,8 @@ var s_chrome_android = mdn.localString({
 
 const desktopBrowsers = {
   chrome: 'Chrome',
-  firefox: 'Firefox',
   edge: 'Edge',
+  firefox: 'Firefox',
   ie: 'Internet Explorer',
   opera: 'Opera',
   safari: 'Safari'

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "mocha-junit-reporter": "1.13.0",
     "jshint": "2.9.4",
     "ejs-lint": "0.3.0",
-    "jsonlint-cli": "1.0.1"
+    "jsonlint-cli": "1.0.1",
+    "tmp": "0.0.31"
   }
 }

--- a/tests/test-loaders.js
+++ b/tests/test-loaders.js
@@ -3,6 +3,7 @@
 var fs = require('fs'),
     path = require('path'),
     assert = require('chai').assert,
+    tmp = require('tmp'),
     kumascript = require('..'),
     ks_loaders = kumascript.loaders,
     ks_test_utils = kumascript.test_utils,
@@ -55,20 +56,17 @@ describe('test-loaders', function () {
     })
 
     it('The FileLoader should detect no macros', function () {
-        var macro_dir = 'tests/no-macros-in-here';
-        fs.mkdirSync(macro_dir);
-        try {
+        tmp.dir({ template: '/tmp/tmp-XXXXXX'}, function (err, path) {
+            if (err) throw err;
             assert.throws(
                 function() {
                     new ks_loaders.FileLoader({
-                        root_dir: macro_dir
+                        root_dir: path
                     });
                 },
                 /no macros could be found in .+/
             );
-        } finally {
-            fs.rmdirSync(macro_dir);
-        }
+        });
     });
 
     it('The FileLoader should detect duplicate macros', function () {


### PR DESCRIPTION
Just implemented your idea from [PR #223](https://github.com/mozilla/kumascript/pull/223) ("Maybe we could make it not do that for root paths starting with a slash."), and that paved the way for your ``tmp`` fix to solve the empty directory issue.

This has been re-based on Mozilla master.