### PR TITLE
use done for test changed from sync to async

### DIFF
--- a/tests/test-loaders.js
+++ b/tests/test-loaders.js
@@ -55,17 +55,19 @@ describe('test-loaders', function () {
         assert.isTrue(cssxref_found, data['macros']);
     })
 
-    it('The FileLoader should detect no macros', function () {
-        tmp.dir({ template: '/tmp/tmp-XXXXXX'}, function (err, path) {
-            if (err) throw err;
-            assert.throws(
-                function() {
-                    new ks_loaders.FileLoader({
-                        root_dir: path
-                    });
-                },
-                /no macros could be found in .+/
-            );
+    it('The FileLoader should detect no macros', function (done) {
+        tmp.dir({template: '/tmp/tmp-XXXXXX'}, function (err, path) {
+            if (!err) {
+                assert.throws(
+                    function() {
+                        new ks_loaders.FileLoader({
+                            root_dir: path
+                        });
+                    },
+                    /no macros could be found in .+/
+                );
+            }
+            done(err);
         });
     });
 


### PR DESCRIPTION
I just noticed that the "The FileLoader should detect no macros" test has become an async test, so changed it to use ``done``. I had also thought we needed to update the ``npm-shrinkwrap.json`` file, but then realized that the ``devDependencies`` are not included in the shrink wrap (with our version of npm).